### PR TITLE
タグなしの画像がキャラクター追加/編集に表示されない件を修正

### DIFF
--- a/src/app/core/component/ImagePickerComponent.vue
+++ b/src/app/core/component/ImagePickerComponent.vue
@@ -130,6 +130,7 @@ export default class ImagePickerComponent extends Mixins<ComponentVue>(
     this.useImageList = this.rawImageList.filter(d => {
       if (!d || !d.data) return false;
       if (regExp && !d.data.name.match(regExp)) return false;
+      if (this.selectImageTag === null) return d.data.tag === "";
       return d.data.tag === this.selectImageTag;
     });
   }


### PR DESCRIPTION
開発お疲れさまです。はじめまして。
一点、不具合らしき挙動を見つけたので、ご確認いただければと思います。

タグなしで登録した画像が、キャラクター追加・キャラクター編集の画像ピックアップに表示されません。

### スクリーンショット

![image](https://user-images.githubusercontent.com/9547451/95655000-409fed00-0b3f-11eb-8b79-2ebea39304e1.png)
![image](https://user-images.githubusercontent.com/9547451/95655021-675e2380-0b3f-11eb-9049-ffe52cd825d4.png)

### 修正の解説について
修正前L133の判定 `d.data.tag === this.selectImageTag` を御覧ください。
`d.data.tag` はタグなしの場合に空文字が入りますが、タグなし画像を選択時の `this.selectImageTag` はnullになるため、タグ無し画像が表示されることはないです。